### PR TITLE
Don't deliver manual pages actually from smartos-live

### DIFF
--- a/manifest
+++ b/manifest
@@ -12187,7 +12187,6 @@ f usr/share/man/man5/iconv_unicode.5 0444 root bin
 f usr/share/man/man5/ieee802.11.5 0444 root bin
 f usr/share/man/man5/ipfilter.5 0444 root bin
 f usr/share/man/man5/isalist.5 0444 root bin
-f usr/share/man/man5/joyent.5 0444 root bin
 f usr/share/man/man5/kerberos.5 0444 root bin
 f usr/share/man/man5/krb5_auth_rules.5 0444 root bin
 f usr/share/man/man5/krb5envvar.5 0444 root bin
@@ -12204,7 +12203,6 @@ f usr/share/man/man5/mm.5 0444 root bin
 f usr/share/man/man5/ms.5 0444 root bin
 f usr/share/man/man5/mutex.5 0444 root bin
 f usr/share/man/man5/nfssec.5 0444 root bin
-f usr/share/man/man5/openssl.5 0444 root bin
 f usr/share/man/man5/pam_allow.5 0444 root bin
 f usr/share/man/man5/pam_authtok_check.5 0444 root bin
 f usr/share/man/man5/pam_authtok_get.5 0444 root bin
@@ -12217,7 +12215,6 @@ f usr/share/man/man5/pam_krb5_migrate.5 0444 root bin
 f usr/share/man/man5/pam_ldap.5 0444 root bin
 f usr/share/man/man5/pam_list.5 0444 root bin
 f usr/share/man/man5/pam_passwd_auth.5 0444 root bin
-f usr/share/man/man5/pam_pkcs11.5 0444 root bin
 f usr/share/man/man5/pam_rhosts_auth.5 0444 root bin
 f usr/share/man/man5/pam_roles.5 0444 root bin
 f usr/share/man/man5/pam_sample.5 0444 root bin
@@ -12247,7 +12244,6 @@ f usr/share/man/man5/tecla.5 0444 root bin
 f usr/share/man/man5/term.5 0444 root bin
 f usr/share/man/man5/threads.5 0444 root bin
 f usr/share/man/man5/vgrindefs.5 0444 root bin
-f usr/share/man/man5/xVM.5 0444 root bin
 f usr/share/man/man5/zones.5 0444 root bin
 d usr/share/man/man7 0755 root bin
 f usr/share/man/man7/FSS.7 0444 root bin


### PR DESCRIPTION
This removes from the manifest all manual pages not actually in illumos.  

A further request against smartos-live will add the sensible ones from there to the smartos-live manifest, and remove the insensible ones entirely.

I think I tested this sensibly (gmake manifest; gmake live; check for errors), in combination with the smartos-live changes alluded to, but I'm not particularly familiar with the smartos build.  Caution is advised.
