### PR TITLE
fix for mfu and mfug fields

### DIFF
--- a/usr/src/cmd/stat/arcstat/arcstat.pl
+++ b/usr/src/cmd/stat/arcstat/arcstat.pl
@@ -290,10 +290,10 @@ sub calculate {
 
 	$v{"arcsz"} = $cur{"size"};
 	$v{"c"} = $cur{"c"};
-	$v{"mfu"} = $d{"hits"}/$int;
+	$v{"mfu"} = $d{"mfu_hits"}/$int;
 	$v{"mru"} = $d{"mru_hits"}/$int;
 	$v{"mrug"} = $d{"mru_ghost_hits"}/$int;
-	$v{"mfug"} = $d{"mru_ghost_hits"}/$int;
+	$v{"mfug"} = $d{"mfu_ghost_hits"}/$int;
 	$v{"eskip"} = $d{"evict_skip"}/$int;
 	$v{"rmiss"} = $d{"recycle_miss"}/$int;
 	$v{"mtxmis"} = $d{"mutex_miss"}/$int;


### PR DESCRIPTION
The mfu and mfug fields are calculated incorrectly.  These appear to be copy/paste errors that date back to the original script.  I've already fixed these in mharsch/arcstat#3 and mharsch/arcstat#5.

If @brendangregg is going to blog about this -- I guess it better be correct :-)
