### PR TITLE
dtrace: Remove CTF label checking

### DIFF
--- a/usr/src/cmd/mdb/common/libstandctf/mapfile
+++ b/usr/src/cmd/mdb/common/libstandctf/mapfile
@@ -70,7 +70,6 @@ SYMBOL_SCOPE {
 		ctf_member_iter;
 		ctf_open;
 		ctf_parent_name;
-		ctf_parent_label;
 		ctf_setmodel;
 		ctf_setspecific;
 		ctf_type_align;

--- a/usr/src/common/ctf/ctf_open.c
+++ b/usr/src/common/ctf/ctf_open.c
@@ -889,16 +889,6 @@ ctf_parent_name(ctf_file_t *fp)
 }
 
 /*
- * Return the label of the parent CTF container, if one exists.  Otherwise
- * return NULL.
- */
-const char *
-ctf_parent_label(ctf_file_t *fp)
-{
-	return (fp->ctf_parlabel);
-}
-
-/*
  * Import the types from the specified parent container by storing a pointer
  * to it in ctf_parent and incrementing its reference count.  Only one parent
  * is allowed: if a parent already exists, it is replaced by the new parent.

--- a/usr/src/lib/libctf/common/mapfile-vers
+++ b/usr/src/lib/libctf/common/mapfile-vers
@@ -68,7 +68,6 @@ SYMBOL_VERSION SUNWprivate_1.2 {
 	ctf_member_info;
 	ctf_parent_file;
 	ctf_parent_name;
-	ctf_parent_label;
 	ctf_set_array;
 	ctf_type_align;
 	ctf_type_cmp;

--- a/usr/src/lib/libdtrace/common/dt_module.c
+++ b/usr/src/lib/libdtrace/common/dt_module.c
@@ -646,17 +646,6 @@ dt_module_getctf(dtrace_hdl_t *dtp, dt_module_t *dmp)
 			goto err;
 		}
 
-		/*
-		 * If the label we claim the parent must have does not match
-		 * its actual topmost label (XXX: Should check all?), ignore
-		 * the CTF entirely rather than acquiring possibly bad type
-		 * references.
-		 */
-		if (strcmp(ctf_label_topmost(pfp), ctf_parent_label(dmp->dm_ctfp)) != 0) {
-			(void) dt_set_errno(dtp, EDT_NOCTF);
-			goto err;
-		}
-
 		if (ctf_import(dmp->dm_ctfp, pfp) == CTF_ERR) {
 			dtp->dt_ctferr = ctf_errno(dmp->dm_ctfp);
 			(void) dt_set_errno(dtp, EDT_CTF);

--- a/usr/src/uts/common/ctf/mapfile
+++ b/usr/src/uts/common/ctf/mapfile
@@ -82,7 +82,6 @@ SYMBOL_SCOPE {
 		ctf_open;
 		ctf_parent_file;
 		ctf_parent_name;
-		ctf_parent_label;
 		ctf_setmodel;
 		ctf_setspecific;
 		ctf_set_array;

--- a/usr/src/uts/common/sys/ctf_api.h
+++ b/usr/src/uts/common/sys/ctf_api.h
@@ -154,7 +154,6 @@ extern void ctf_close(ctf_file_t *);
 
 extern ctf_file_t *ctf_parent_file(ctf_file_t *);
 extern const char *ctf_parent_name(ctf_file_t *);
-extern const char *ctf_parent_label(ctf_file_t *);
 
 extern int ctf_import(ctf_file_t *, ctf_file_t *);
 extern int ctf_setmodel(ctf_file_t *, int);

--- a/usr/src/uts/intel/dtrace/fbt.c
+++ b/usr/src/uts/intel/dtrace/fbt.c
@@ -629,11 +629,6 @@ fbt_getargdesc(void *arg, dtrace_id_t id, void *parg, dtrace_argdesc_t *desc)
 			goto err;
 		}
 
-                if (strcmp(ctf_label_topmost(pfp), ctf_parent_label(fp)) != 0) {
-			ctf_close(pfp);
-			goto err;
-		}
-
 		if (ctf_import(fp, pfp) != 0) {
 			ctf_close(pfp);
 			goto err;

--- a/usr/src/uts/sparc/dtrace/fbt.c
+++ b/usr/src/uts/sparc/dtrace/fbt.c
@@ -1657,11 +1657,6 @@ fbt_getargdesc(void *arg, dtrace_id_t id, void *parg, dtrace_argdesc_t *desc)
 		if ((pfp = ctf_modopen(mod->mod_mp, &error)) == NULL)
 			goto err;
 
-		if (strcmp(ctf_label_topmost(pfp), ctf_parent_label(fp)) != 0) {
-			ctf_close(pfp);
-			goto err;
-		}
-
 		if (ctf_import(fp, pfp) != 0) {
 			ctf_close(pfp);
 			goto err;


### PR DESCRIPTION
It is incomplete, and was pulled into smartos as a result of miscommunication.

---

Due to an accident that's probably my fault, SmartOS ended up containing an early version of my changes to make DTrace verify that CTF information was consistent prior to using it.  Unfortunately, this implementation is toxic to incremental builds across a change to the version string, as DTrace will refuse to use any CTF (as genunix will have been rebuilt, but nothing else will).  Fixing this problem more completely has thus far proved challenging, so I'd rather this get removed rather than waiting on me to make a correct fix to illumos.

You should still be safe from the classical CTF badness with the closed-bins, because you _did_ merge with Jason's ctfstrip, via my gcc/upgrade branch, so your closed-bins are cleansed.

I haven't tested this, beyond doing a brief build to make sure nothing was massively wrong, and I'm not trivially set up _to_ test it.  What it does is backout any changeset present in the `ctf/check-parent-label` branch of richlowe/illumos-gate which is not also in illumos/illumos-gate.

/cc @JohnSonnenschein
