### PR TITLE
Allow nicstat to view net interfaces

### DIFF
--- a/usr/src/cmd/nicstat/nicstat.pl
+++ b/usr/src/cmd/nicstat/nicstat.pl
@@ -136,7 +136,7 @@ $main::opt_h = 0;
 $| = 1;                      # autoflush
 
 # kstat "link" module includes:
-my @Network = qw(dmfe bge be bnx ce eri external ge hme igb ige internal ixgbe le ppp qfe rtls);
+my @Network = qw(dmfe bge be bnx ce eri external ge hme igb ige internal ixgbe le net ppp qfe rtls);
 my %Network;
 $Network{$_} = 1 foreach (@Network);
 my $ZONENAME = `/usr/bin/zonename`;


### PR DESCRIPTION
SmartOS zones in the JPC get interfaces named net0, net1, etc. `nicstat` seems helpful, but does not recognize these as available interfaces.