### PR TITLE
OS-3613 lxbrand convert ioctl to IKE (fix manifest)

### DIFF
--- a/manifest
+++ b/manifest
@@ -4583,9 +4583,6 @@ f usr/kernel/sched/amd64/RT_DPTBL 0755 root sys
 d usr/kernel/socketmod 0755 root sys
 d usr/kernel/socketmod/amd64 0755 root sys
 f usr/kernel/socketmod/amd64/sockpfp 0755 root sys
-d usr/kernel/strmod 0755 root sys
-d usr/kernel/strmod/amd64 0755 root sys
-f usr/kernel/strmod/amd64/ldlinux 0755 root sys
 d usr/kernel/sys 0755 root sys
 d usr/kernel/sys/amd64 0755 root sys
 f usr/kernel/sys/amd64/acctctl 0755 root sys


### PR DESCRIPTION
Build was broken for me. This manifest fixes things, though I'm not 100% certain it's correct. Hopefully @pfmooney can eyeball this and confirm

Build error was:

```
ERROR: copy onto the image failed
(may need to increase the size or manifest file not found)
Failures:
FILE: [usr/kernel/strmod/amd64/ldlinux][0755][root/0][sys/3]: FAILED
gmake[1]: *** [live] Error 1
gmake[1]: Leaving directory `/ws/mg/MG/build/smartos-live'
gmake: *** [/ws/mg/MG/bits/platform/platform-build-smartos-20141207T033334Z.tgz] Error 2
```
