### PR TITLE
Bugfix for sendmail and mailwrapper usage

### DIFF
--- a/manifest
+++ b/manifest
@@ -10493,7 +10493,7 @@ f usr/sbin/rwall 0555 root bin
 f usr/sbin/sacadm 4755 root sys
 f usr/sbin/safe_finger 0555 root bin
 f usr/sbin/sbdadm 0555 root bin
-s usr/sbin/sendmail=../lib/smtp/sendmail/sendmail
+s usr/sbin/sendmail=../lib/mailwrapper
 f usr/sbin/setmnt 0555 root bin
 h usr/sbin/share=usr/sbin/sharemgr
 f usr/sbin/shareall 0555 root bin


### PR DESCRIPTION
I think /usr/sbin/sendmail should also be linked to the mailwrapper.
On the original commit at the illumos repository they also create a
symlink for the sbin files to mailwrapper.

https://github.com/illumos/illumos-gate/commit/287247a826fa2ab8d01f6c8f276d405eb08420f8