### PR TITLE
Compare LX minor to the LX_MINORMASK, not the Solaris minor

### DIFF
--- a/usr/src/lib/brand/lx/lx_brand/common/stat.c
+++ b/usr/src/lib/brand/lx/lx_brand/common/stat.c
@@ -162,7 +162,7 @@ lx_stat_init()
 			} else {
 				/* make sure the major node matches */
 				assert(getmajor(st.st_rdev) == major);
-				assert(mt[j].mt_minor < LX_MINORMASK);
+				assert(mt[j].mt_lx_minor < LX_MINORMASK);
 			}
 
 			/* save the minor node value */
@@ -277,7 +277,7 @@ s2l_devt(dev_t dev, lx_dev_t *jdev, int fd)
 			mt = devt_translators[i].dt_list;
 			for (j = 0; mt[j].mt_path != NULL; j++) {
 				if (mt[j].mt_minor == min) {
-					assert(mt[j].mt_minor < LX_MINORMASK);
+					assert(mt[j].mt_lx_minor < LX_MINORMASK);
 
 					/* found a translation */
 					*jdev = LX_MAKEDEVICE(


### PR DESCRIPTION
Otherwise we will hit this assert while processing zcons devices on CNs with > ~128 zones.