### PR TITLE
possible null pointer dereference in toxic library check

### DIFF
--- a/usr/src/cmd/sgs/rtld/common/analyze.c
+++ b/usr/src/cmd/sgs/rtld/common/analyze.c
@@ -845,6 +845,10 @@ static int
 is_load_toxic(Lm_list *lml, Rt_map *nlmp)
 {
 	const char	*fpath = PATHNAME(nlmp);
+	if (fpath == NULL) {
+		return (0);
+	}
+
 	size_t		flen = strlen(fpath);
 	Pdesc 		*pdp;
 	Aliste 		idx;


### PR DESCRIPTION
Calling ldd on a file segfaulted and produced a stacktrace like this:

```
fffffd7fffdff140 ld.so.1`strlen+0x30()
fffffd7fffdff200 ld.so.1`load_finish+0x56(fffffd7fff3fd4a0, fffffd7fff360060, fffffd7fff350990, 1901, 2000, 0)
fffffd7fffdff2c0 ld.so.1`load_path+0xa5(fffffd7fff3fd4a0, 20, fffffd7fff350990, 1901, 2000, 0)
fffffd7fffdff430 ld.so.1`load_one+0x190(fffffd7fff3fd4a0, 20, fffffd7fff380c18, fffffd7fff350990, 1901, 2000)
fffffd7fffdff4f0 ld.so.1`preload+0x2a3(fffffd7fffdffce8, fffffd7fff350990, fffffd7fffdff7c8)
fffffd7fffdff830 ld.so.1`setup+0x1606(fffffd7fffdff9f8, fffffd7fffdffb10, 0, fffffd7fffdfffbf, 1000, fffffd7fff3aba44)
fffffd7fffdff950 ld.so.1`_setup+0x282(fffffd7fffdff960, 190)
fffffd7fffdff9e0 ld.so.1`_rt_boot+0x6c()
0000000000000001 0xfffffd7fffdffc00()
```

With this null check in place it does not crash anymore.