### PR TITLE
OS-???? [lx] honor SS_DISABLE in sigaltstack()

### DIFF
--- a/usr/src/lib/brand/lx/lx_brand/common/signal.c
+++ b/usr/src/lib/brand/lx/lx_brand/common/signal.c
@@ -644,6 +644,11 @@ lx_sigaltstack(uintptr_t ssp, uintptr_t oss)
 		    LX_MINSIGSTKSZ) {
 			return (-ENOMEM);
 		}
+
+		if ((ss.ss_flags & LX_SS_DISABLE) != 0) {
+			ss.ss_sp = NULL;
+			ss.ss_size = 0;
+		}
 	}
 
 	if (oss != NULL) {


### PR DESCRIPTION
Fixes #70.

I also verified the same behavior between Linux and lx via strace. Even if you call `sigaltstack(2)` twice in a row with two different memory locations it always reverts back to `NULL` when disabled, not the previous setting (I checked this behavior because I wasn't 100% sure after reading the man page).