### PR TITLE
in.ndpd: SIOCLIFGETND: fix missing newline

### DIFF
--- a/usr/src/cmd/cmd-inet/usr.lib/in.ndpd/ndp.c
+++ b/usr/src/cmd/cmd-inet/usr.lib/in.ndpd/ndp.c
@@ -1554,7 +1554,7 @@ update_ra_flag(const struct phyint *pi, const struct sockaddr_in6 *from,
 		if (errno == ESRCH) {
 			if (debug & D_IFSCAN) {
 				logmsg(LOG_DEBUG,
-"update_ra_flag: SIOCLIFGETND: nce doesn't exist, not setting IFF_ROUTER");
+"update_ra_flag: SIOCLIFGETND: nce doesn't exist, not setting IFF_ROUTER\n");
 			}
 		} else {
 			logperror_pi(pi, "update_ra_flag: SIOCLIFGETND");


### PR DESCRIPTION
Fix missing newline to prevent D_IFSCAN debug message concatenation with the next debug message.