### PR TITLE
OS-5221 nfs mount should work without /etc/nfssec.conf inside LX zoneroot

### DIFF
--- a/usr/src/cmd/fs.d/nfs/lib/nfs_sec.c
+++ b/usr/src/cmd/fs.d/nfs/lib/nfs_sec.c
@@ -45,6 +45,7 @@
 #include <stdlib.h>
 #include <syslog.h>
 #include <synch.h>
+#include <zone.h>
 #include <rpc/rpc.h>
 #include <nfs/nfs_sec.h>
 #include <rpc/rpcsec_gss.h>
@@ -707,12 +708,17 @@ get_seconfig(int whichway, char *name, int num,
 {
 	char	line[BUFSIZ];	/* holds each line of NFSSEC_CONF */
 	FILE	*fp;		/* file stream for NFSSEC_CONF */
+	char	nfssec_conf[MAXPATHLEN];
+	const char *zroot = zone_get_nroot();
 
 	if ((whichway == GETBYNAME) && (name == NULL))
 		return (SC_NOTFOUND);
 
+	(void) snprintf(nfssec_conf, sizeof (nfssec_conf), "%s%s", zroot != NULL ?
+	    zroot : "", NFSSEC_CONF);
+
 	(void) mutex_lock(&matching_lock);
-	if ((fp = fopen(NFSSEC_CONF, "r")) == NULL) {
+	if ((fp = fopen(nfssec_conf, "r")) == NULL) {
 		(void) mutex_unlock(&matching_lock);
 		return (SC_OPENFAIL);
 	}

--- a/usr/src/lib/brand/lx/zone/platform.xml
+++ b/usr/src/lib/brand/lx/zone/platform.xml
@@ -51,6 +51,8 @@
 	    directory="/native/etc/default/dhcpagent" type="lofs" opt="ro" />
 	<global_mount special="/etc/netconfig"
 	    directory="/native/etc/netconfig" type="lofs" opt="ro" />
+	<global_mount special="/etc/nfssec.conf"
+	    directory="/native/etc/nfssec.conf" type="lofs" opt="ro" />
 	<global_mount special="/sbin"
 	    directory="/native/sbin" opt="ro,nodevices" type="lofs" />
 	<global_mount special="/usr/lib/brand/lx/ld" directory="/var/ld"


### PR DESCRIPTION
In order to mount NFS volumes, we need to be able to run something like:

```
/native/usr/lib/fs/nfs/mount -o vers=3,sec=sys 10.128.0.8:/data /data
```

but this requires /etc/nfssec.conf to be in the zone's root. Since we don't want to have to insert this into every docker image, this PR adds the nfssec.conf file to /native and adds a call to zone_get_nroot() so that when mounting on LX using the native mount, we'll look at the /native/* file instead of the one in the zoneroot.