### PR TITLE
OS-8037 ahci_em_suspend() incorrectly VERIFY()s mutex_owned()

### DIFF
--- a/usr/src/uts/common/io/sata/adapters/ahci/ahci.c
+++ b/usr/src/uts/common/io/sata/adapters/ahci/ahci.c
@@ -82,7 +82,6 @@
  */
 
 #include <sys/note.h>
-#include <sys/debug.h>
 #include <sys/scsi/scsi.h>
 #include <sys/pci.h>
 #include <sys/disp.h>
@@ -10840,19 +10839,22 @@ static void
 ahci_em_quiesce(ahci_ctl_t *ahci_ctlp)
 {
 	ASSERT(ahci_ctlp->ahcictl_em_flags & AHCI_EM_PRESENT);
-	VERIFY(mutex_owned(&ahci_ctlp->ahcictl_mutex));
 
+	mutex_enter(&ahci_ctlp->ahcictl_mutex);
 	ahci_ctlp->ahcictl_em_flags |= AHCI_EM_QUIESCE;
+	mutex_exit(&ahci_ctlp->ahcictl_mutex);
+
 	ddi_taskq_wait(ahci_ctlp->ahcictl_em_taskq);
 }
 
 static void
 ahci_em_suspend(ahci_ctl_t *ahci_ctlp)
 {
-	VERIFY(mutex_owned(&ahci_ctlp->ahcictl_mutex));
-
 	ahci_em_quiesce(ahci_ctlp);
+
+	mutex_enter(&ahci_ctlp->ahcictl_mutex);
 	ahci_ctlp->ahcictl_em_flags &= ~AHCI_EM_READY;
+	mutex_exit(&ahci_ctlp->ahcictl_mutex);
 }
 
 static void
@@ -10873,10 +10875,7 @@ ahci_em_fini(ahci_ctl_t *ahci_ctlp)
 		return;
 	}
 
-	mutex_enter(&ahci_ctlp->ahcictl_mutex);
 	ahci_em_quiesce(ahci_ctlp);
-	mutex_exit(&ahci_ctlp->ahcictl_mutex);
-
 	ddi_taskq_destroy(ahci_ctlp->ahcictl_em_taskq);
 	ahci_ctlp->ahcictl_em_taskq = NULL;
 }


### PR DESCRIPTION
The original fix for OS-7672 is incompatible with what went into illumos as 10055, so revert it.