### PR TITLE
OS-8049 make_test requires /usr/bin/make

### DIFF
--- a/usr/src/pkg/manifests/system-test-smartostest.mf
+++ b/usr/src/pkg/manifests/system-test-smartostest.mf
@@ -45,6 +45,8 @@ file path=usr/bin/ctfmerge mode=0555
 # so we need to redeliver isaexec in order to create the
 # proto area correctly.
 file path=usr/lib/isaexec
+# Needed by make_test
+file path=usr/bin/make mode=0555
 
 license cr_Sun license=cr_Sun
 license lic_CDDL license=lic_CDDL


### PR DESCRIPTION
This will still fail in the results until "make_test" itself is fixed upstream, hopefully soon.