### PR TITLE
Added MemAvailable to lx procfs.

### DIFF
--- a/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
+++ b/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
@@ -3991,22 +3991,24 @@ lxpr_read_meminfo(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 	 * model, so just inform the caller that no swap is being used.
 	 */
 	lxpr_uiobuf_printf(uiobuf,
-	    "MemTotal:  %8lu kB\n"
-	    "MemFree:   %8lu kB\n"
-	    "MemShared: %8u kB\n"
-	    "Buffers:   %8u kB\n"
-	    "Cached:    %8u kB\n"
-	    "SwapCached:%8u kB\n"
-	    "Active:    %8u kB\n"
-	    "Inactive:  %8u kB\n"
-	    "HighTotal: %8u kB\n"
-	    "HighFree:  %8u kB\n"
-	    "LowTotal:  %8u kB\n"
-	    "LowFree:   %8u kB\n"
-	    "SwapTotal: %8lu kB\n"
-	    "SwapFree:  %8lu kB\n",
+	    "MemTotal:       %8lu kB\n"
+	    "MemFree:        %8lu kB\n"
+	    "MemAvailable:   %8lu kB\n"
+	    "MemShared:      %8u kB\n"
+	    "Buffers:        %8u kB\n"
+	    "Cached:         %8u kB\n"
+	    "SwapCached:     %8u kB\n"
+	    "Active:         %8u kB\n"
+	    "Inactive:       %8u kB\n"
+	    "HighTotal:      %8u kB\n"
+	    "HighFree:       %8u kB\n"
+	    "LowTotal:       %8u kB\n"
+	    "LowFree:        %8u kB\n"
+	    "SwapTotal:      %8lu kB\n"
+	    "SwapFree:       %8lu kB\n",
 	    btok(total_mem),				/* MemTotal */
 	    btok(free_mem),				/* MemFree */
+	    btok(free_mem),				/* MemAvailable */
 	    0,						/* MemShared */
 	    0,						/* Buffers */
 	    0,						/* Cached */

--- a/usr/src/uts/common/fs/lxproc/lxpr_vnops.c
+++ b/usr/src/uts/common/fs/lxproc/lxpr_vnops.c
@@ -1472,24 +1472,26 @@ lxpr_read_meminfo(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 	    "        total:     used:    free:  shared: buffers:  cached:\n"
 	    "Mem:  %8lu %8lu %8lu %8u %8u %8u\n"
 	    "Swap: %8lu %8lu %8lu\n"
-	    "MemTotal:  %8lu kB\n"
-	    "MemFree:   %8lu kB\n"
-	    "MemShared: %8u kB\n"
-	    "Buffers:   %8u kB\n"
-	    "Cached:    %8u kB\n"
-	    "SwapCached:%8u kB\n"
-	    "Active:    %8u kB\n"
-	    "Inactive:  %8u kB\n"
-	    "HighTotal: %8u kB\n"
-	    "HighFree:  %8u kB\n"
-	    "LowTotal:  %8u kB\n"
-	    "LowFree:   %8u kB\n"
-	    "SwapTotal: %8lu kB\n"
-	    "SwapFree:  %8lu kB\n",
+	    "MemTotal:     %8lu kB\n"
+	    "MemFree:      %8lu kB\n"
+	    "MemAvailable: %8lu kB\n"
+	    "MemShared:    %8u kB\n"
+	    "Buffers:      %8u kB\n"
+	    "Cached:       %8u kB\n"
+	    "SwapCached:   %8u kB\n"
+	    "Active:       %8u kB\n"
+	    "Inactive:     %8u kB\n"
+	    "HighTotal:    %8u kB\n"
+	    "HighFree:     %8u kB\n"
+	    "LowTotal:     %8u kB\n"
+	    "LowFree:      %8u kB\n"
+	    "SwapTotal:    %8lu kB\n"
+	    "SwapFree:     %8lu kB\n",
 	    total_mem, total_mem - free_mem, free_mem, 0, 0, 0,
 	    total_swap, used_swap, total_swap - used_swap,
 	    btok(total_mem),				/* MemTotal */
 	    btok(free_mem),				/* MemFree */
+	    btok(free_mem),				/* MemAvailable */
 	    0,						/* MemShared */
 	    0,						/* Buffers */
 	    0,						/* Cached */


### PR DESCRIPTION
Some scripts are reading  /proc/meminfo entry to determine available memory. 
MemAvailable entry is available since Linux Kernel +3.14 
For example: https://github.com/GameServerManagers/LinuxGSM/blob/69ec2ecced43433dec2a96755f89ef98e0891b33/lgsm/functions/info_distro.sh
is using this entry.

Signed-off-by: neirac <cneirabustos@gmail.com>