### PR TITLE
dladm create-overlay crashes if search plugin is not provided

### DIFF
--- a/usr/src/cmd/dladm/dladm.c
+++ b/usr/src/cmd/dladm/dladm.c
@@ -9936,7 +9936,7 @@ do_create_overlay(int argc, char *argv[], const char *use)
 	if (encap == NULL)
 		die("missing required encapsulation plugin");
 
-	if (encap == NULL)
+	if (search == NULL)
 		die("missing required search plugin");
 
 	if (optind != (argc - 1))


### PR DESCRIPTION
This is an incorrect invocation of the command, but if the encapsulation and vid are provided without the search plugin, then it crashes due to checking the encaps field twice instead of once for encaps and once for search.

```
# dladm create-overlay -e vxlan -v 23 overlay0
zsh: segmentation fault (core dumped)  dladm create-overlay -e vxlan -v 23 overlay0
```
