### PR TITLE
OS-8190 zone_alias bash completion stomps all over shell variables that we happen to use all the time

### DIFF
--- a/usr/src/cmd/nsadmin/bash/bash_completion.d/zone_alias
+++ b/usr/src/cmd/nsadmin/bash/bash_completion.d/zone_alias
@@ -1,5 +1,6 @@
 _zone_alias()
 {
+    local RES alias completed_alias results_arr uuid
     # Attempt alias -> uuid mapping
     alias="${COMP_WORDS[COMP_CWORD]}"
     RES=$(vmadm list -H -o alias,uuid | awk -v alias="$alias" '


### PR DESCRIPTION
Change-Id: I5aa29572a26fe220d3ec75e3382fb66d19c8202f

I tested this by hot patching the zone_alias file and `exec`ing bash, then trying alias completion.