### PR TITLE
OS-8181 exposed fault in lx netlink bind/sendto

### DIFF
--- a/usr/src/uts/common/brand/lx/io/lx_netlink.c
+++ b/usr/src/uts/common/brand/lx/io/lx_netlink.c
@@ -568,7 +568,7 @@ lx_netlink_bind(sock_lower_handle_t handle, struct sockaddr *name,
 	lx_netlink_sock_t *lxsock = (lx_netlink_sock_t *)handle;
 	lx_netlink_sockaddr_t *lxsa = (lx_netlink_sockaddr_t *)name;
 
-	if (namelen != sizeof (lx_netlink_sockaddr_t) ||
+	if (namelen < sizeof (lx_netlink_sockaddr_t) ||
 	    lxsa->lxnl_family != AF_LX_NETLINK) {
 		return (EINVAL);
 	}
@@ -1974,7 +1974,7 @@ lx_netlink_send(sock_lower_handle_t handle, mblk_t *mp,
 		lx_netlink_sockaddr_t *lxsa =
 		    (lx_netlink_sockaddr_t *)msg->msg_name;
 
-		if (msg->msg_namelen != sizeof (lx_netlink_sockaddr_t) ||
+		if (msg->msg_namelen < sizeof (lx_netlink_sockaddr_t) ||
 		    lxsa->lxnl_family != AF_LX_NETLINK) {
 			return (EINVAL);
 		}


### PR DESCRIPTION
See https://github.com/omniosorg/illumos-omnios/issues/794 for analysis and details for this.

Basically, OS-8181 got `getsockopt(SO_PROTOCOL)` working on netlink sockets, which enabled `systemd` to get further and trigger an assertion failure.