### PR TITLE
LX: netlink errors have spurious flags

### DIFF
--- a/usr/src/uts/common/brand/lx/io/lx_netlink.c
+++ b/usr/src/uts/common/brand/lx/io/lx_netlink.c
@@ -11,6 +11,7 @@
 
 /*
  * Copyright 2018 Joyent, Inc.
+ * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*
@@ -922,6 +923,7 @@ lx_netlink_reply_done(lx_netlink_reply_t *reply)
 		hdr->lxnh_len = sizeof (lx_netlink_err_t);
 		hdr->lxnh_seq = reply->lxnr_hdr.lxnh_seq;
 		hdr->lxnh_pid = lxsock->lxns_port;
+		hdr->lxnh_flags = 0;
 	} else {
 		uint32_t status = 0;
 


### PR DESCRIPTION
This fixes "random" lx zone boot hangs.

Write-up at https://github.com/omniosorg/illumos-omnios/issues/798