### PR TITLE
Wire up IP_RECVTOS and IPV6_RECVTCLASS in lx

### DIFF
--- a/usr/src/uts/common/brand/lx/syscall/lx_socket.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_socket.c
@@ -23,7 +23,7 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2020 Joyent, Inc.
- * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #include <sys/errno.h>
@@ -706,12 +706,16 @@ static lx_cmsg_xlate_t lx_cmsg_xlate_tbl[] = {
 	    LX_IPPROTO_IP, LX_IP_PKTINFO, cmsg_conv_generic },
 	{ IPPROTO_IP, IP_RECVTTL, stol_conv_recvttl,
 	    LX_IPPROTO_IP, LX_IP_TTL, NULL },
+	{ IPPROTO_IP, IP_RECVTOS, cmsg_conv_generic,
+	    LX_IPPROTO_IP, LX_IP_TOS, cmsg_conv_generic },
 	{ IPPROTO_IP, IP_TTL, cmsg_conv_generic,
 	    LX_IPPROTO_IP, LX_IP_TTL, cmsg_conv_generic },
 	{ IPPROTO_IPV6, IPV6_HOPLIMIT, cmsg_conv_generic,
 	    LX_IPPROTO_IPV6, LX_IPV6_HOPLIMIT, cmsg_conv_generic },
 	{ IPPROTO_IPV6, IPV6_PKTINFO, cmsg_conv_generic,
-	    LX_IPPROTO_IPV6, LX_IPV6_PKTINFO, cmsg_conv_generic }
+	    LX_IPPROTO_IPV6, LX_IPV6_PKTINFO, cmsg_conv_generic },
+	{ IPPROTO_IPV6, IPV6_TCLASS, cmsg_conv_generic,
+	    LX_IPPROTO_IPV6, LX_IPV6_TCLASS, cmsg_conv_generic }
 };
 
 #define	LX_MAX_CMSG_XLATE	\
@@ -2664,7 +2668,7 @@ static const lx_sockopt_map_t ltos_ip_sockopts[LX_IP_UNICAST_IF + 1] = {
 	{ OPTNOTSUP, 0 },			/* IP_MTUDISCOVER	*/
 	{ OPTNOTSUP, 0 },			/* IP_RECVERR		*/
 	{ IP_RECVTTL, sizeof (int) },		/* IP_RECVTTL		*/
-	{ OPTNOTSUP, 0 },			/* IP_RECVTOS		*/
+	{ IP_RECVTOS, sizeof (int) },		/* IP_RECVTOS		*/
 	{ OPTNOTSUP, 0 },			/* IP_MTU		*/
 	{ OPTNOTSUP, 0 },			/* IP_FREEBIND		*/
 	{ OPTNOTSUP, 0 },			/* IP_IPSEC_POLICY	*/
@@ -2774,7 +2778,7 @@ static const lx_sockopt_map_t ltos_ipv6_sockopts[LX_IPV6_TCLASS + 1] = {
 	{ OPTNOTSUP, 0 },
 	{ OPTNOTSUP, 0 },
 	{ OPTNOTSUP, 0 },
-	{ OPTNOTSUP, 0 },			/* IPV6_RECVTCLASS	*/
+	{ IPV6_RECVTCLASS, sizeof (int) },	/* IPV6_RECVTCLASS	*/
 	{ IPV6_TCLASS, sizeof (int) }		/* IPV6_TCLASS		*/
 };
 


### PR DESCRIPTION
https://www.illumos.org/issues/13175 recently added support for IP_RECVTOS to gate, and gate already has support for IPV6_RECVTCLASS. These should be wired up for LX.

Fixes #330 

```
[root@lx ~]# cat /etc/motd
   __        .                   .
 _|  |_      | .-. .  . .-. :--. |-
|_    _|     ;|   ||  |(.-' |  | |
  |__|   `--'  `-' `;-| `-' '  ' `-'
                   /  ;  Instance (CentOS 7.4 20180323)
                   `-'   https://docs.joyent.com/images/container-native-linux

[root@lx ~]# yum install bind
...
[root@lx ~]# systemctl start named
[root@lx ~]# ps -ef | grep named
root      5549  5288  0 10:13 pts/2    00:00:00 grep --color=auto named
named     5529     1  0 10:13 ?        00:00:00 /usr/sbin/named -u named -c /etc/named.conf
[root@lx ~]# cat /var/named/data/named.run
managed-keys-zone: loaded serial 0
zone 0.in-addr.arpa/IN: loaded serial 0
zone localhost.localdomain/IN: loaded serial 0
zone 1.0.0.127.in-addr.arpa/IN: loaded serial 0
zone localhost/IN: loaded serial 0
zone 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa/IN: loaded serial 0
all zones loaded
running
managed-keys-zone: Key 20326 for zone . acceptance timer complete: key now trusted
resolver priming query complete
```

Dtrace while starting named shows IP_RECVTOS being set and at least no longer failing.

```
bloody# dtrace -n 'lx-syscall::setsockopt:entry/arg2 == 13 || arg2 == 57/{self->a = arg2}' -n 'lx-syscall::setsockopt:return/self->a/{printf("setsockopt(..., %d, ...) = %d", self->a, arg1); self->a = 0}'
dtrace: description 'lx-syscall::setsockopt:entry' matched 1 probe
dtrace: description 'lx-syscall::setsockopt:return' matched 1 probe
CPU     ID                    FUNCTION:NAME
  7   4232                setsockopt:return setsockopt(..., 13, ...) = 0
  7   4232                setsockopt:return setsockopt(..., 13, ...) = 0
  7   4232                setsockopt:return setsockopt(..., 13, ...) = 0
  2   4232                setsockopt:return setsockopt(..., 13, ...) = 0
 10   4232                setsockopt:return setsockopt(..., 13, ...) = 0
 10   4232                setsockopt:return setsockopt(..., 13, ...) = 0
 12   4232                setsockopt:return setsockopt(..., 13, ...) = 0
 12   4232                setsockopt:return setsockopt(..., 13, ...) = 0
```
Using a slightly modified* version of `usr/src/test/os-tests/tests/sockfs/recvmsg.c ` from illumos-gate:
```
[root@lx ~]# ./recvmsg
[PASS] baseline
[PASS] recv TOS
[PASS] recv TTL
[PASS] recv PKTINFO
[PASS] recv TOS,TTL
[PASS] recv TTL,PKTINFO
[PASS] recv TOS,PKTINFO
[PASS] recv TOS,TTL,PKTINFO
[PASS] set TOS,TTL
[PASS] set/recv TOS,TTL
[PASS] set TOS,TTL, recv PKTINFO
[PASS] set TOS,TTL, recv TOS,TTL,PKTINFO
[PASS] STREAM set TOS
```

* - Linux uses IP_TOS and IP_TTL for the ancillary data rather than IP_RECVTOS and IP_RECVTTL that illumos and *BSD do.

This only tests UDP IP_RECVTOS, I also set up two zones and manually tested the TCP variant between them.
I cannot easily test the IPV6_RECVTCLASS in this environment.