### PR TITLE
OS-8280 Add /proc/sys/kernel/random/uuid to LX brands

### DIFF
--- a/usr/src/uts/common/brand/lx/procfs/lx_proc.h
+++ b/usr/src/uts/common/brand/lx/procfs/lx_proc.h
@@ -225,6 +225,7 @@ typedef enum lxpr_nodetype {
 	LXPR_SYS_KERNEL_RANDDIR,	/* /proc/sys/kernel/random */
 	LXPR_SYS_KERNEL_RAND_BOOTID, /* /proc/sys/kernel/random/boot_id */
 	LXPR_SYS_KERNEL_RAND_ENTAVL, /* /proc/sys/kernel/random/entropy_avail */
+	LXPR_SYS_KERNEL_RAND_UUID, /* /proc/sys/kernel/random/uuid */
 	LXPR_SYS_KERNEL_SEM,		/* /proc/sys/kernel/sem		*/
 	LXPR_SYS_KERNEL_SHMALL,		/* /proc/sys/kernel/shmall	*/
 	LXPR_SYS_KERNEL_SHMMAX,		/* /proc/sys/kernel/shmmax	*/

--- a/usr/src/uts/common/brand/lx/sys/lx_brand.h
+++ b/usr/src/uts/common/brand/lx/sys/lx_brand.h
@@ -41,6 +41,7 @@
 #include <sys/cpuvar.h>
 #include <sys/lx_futex.h>
 #include <sys/lx_userhz.h>
+#include <sys/uuid.h>
 #endif
 
 #ifdef	__cplusplus
@@ -397,9 +398,6 @@ typedef struct lx_proc_data {
 #define	LX_AFF_ULONGS	(LX_NCPU / (8 * sizeof (ulong_t)))
 typedef ulong_t lx_affmask_t[LX_AFF_ULONGS];
 
-/* Length of proc boot_id string */
-#define	LX_BOOTID_LEN	37
-
 /*
  * Flag values for uc_brand_data[0] in the ucontext_t:
  */
@@ -637,7 +635,7 @@ typedef struct lx_zone_data {
 	char lxzd_kernel_release[LX_KERN_RELEASE_MAX];
 	char lxzd_kernel_version[LX_KERN_VERSION_MAX];
 	ksocket_t lxzd_ioctl_sock;
-	char lxzd_bootid[LX_BOOTID_LEN];	/* procfs boot_id */
+	char lxzd_bootid[UUID_PRINTABLE_STRING_LENGTH];	/* procfs boot_id */
 	gid_t lxzd_ttygrp;			/* tty gid for pty chown */
 	vfs_t *lxzd_cgroup;			/* cgroup for this zone */
 	pid_t lxzd_lockd_pid;			/* pid of NFS lockd */


### PR DESCRIPTION
/proc/sys/kernel/random/uuid generates a random UUID on each read and is used by software such as xapian.