### PR TITLE
duplicate symbol 'taskq_empty' in libfakekernel mapfile-vers

### DIFF
--- a/usr/src/lib/libfakekernel/common/mapfile-vers
+++ b/usr/src/lib/libfakekernel/common/mapfile-vers
@@ -239,7 +239,6 @@ SYMBOL_VERSION SUNWprivate_1.1 {
 	taskq_dispatch_ent;
 	taskq_empty;
 	taskq_member;
-	taskq_empty;
 	taskq_wait;
 	taskq_wait_id;
 


### PR DESCRIPTION
just remove duplicate entry.