### PR TITLE
OS-8737 Want to swap in experimental bhyve binary on a per-zone basis

### DIFF
--- a/usr/src/cmd/zhyve/zhyve.c
+++ b/usr/src/cmd/zhyve/zhyve.c
@@ -190,8 +190,7 @@ try_bhyve_override(char **argv)
 		    "(%zd byte(s), need 2)\n", BHYVE_ZONE_PATH, slen);
 		exit(EXIT_FAILURE);
 	}
-	is_script = (shebang[0] == '#' && shebang[1] == '!') ?
-	    B_TRUE : B_FALSE;
+	is_script = (shebang[0] == '#' && shebang[1] == '!');
 
 	/*
 	 * `resolved` is both the script exec target and the log label.

--- a/usr/src/cmd/zhyve/zhyve.c
+++ b/usr/src/cmd/zhyve/zhyve.c
@@ -216,11 +216,11 @@ try_bhyve_override(char **argv)
 	resolved[rlen] = '\0';
 
 	if (strcmp(resolved, BHYVE_ZONE_PATH) != 0) {
-		(void) printf("Using bhyve override at %s -> %s\n",
+		(void) fprintf(stderr, "Using bhyve override at %s -> %s\n",
 		    BHYVE_ZONE_PATH, resolved);
 	} else {
-		(void) printf("Using bhyve override at %s\n",
-		    BHYVE_ZONE_PATH);
+		(void) fprintf(stderr, "Using bhyve override at %s\n",
+		    resolved);
 	}
 
 	if (is_script) {
@@ -230,7 +230,7 @@ try_bhyve_override(char **argv)
 	} else {
 		(void) fexecve(fd, argv, environ);
 		(void) fprintf(stderr, "fexecve(%s) failed: %s\n",
-		    BHYVE_ZONE_PATH, strerror(errno));
+		    resolved, strerror(errno));
 	}
 	exit(EXIT_FAILURE);
 }

--- a/usr/src/cmd/zhyve/zhyve.c
+++ b/usr/src/cmd/zhyve/zhyve.c
@@ -23,6 +23,10 @@
  * inside the zone, exec it instead of the platform's bhyve.  This lets a
  * zone image ship an alternate bhyve (or a wrapper that performs additional
  * setup, e.g. starting swtpm) without requiring a platform image rebuild.
+ * A present-but-invalid BHYVE_ZONE_PATH (non-regular, missing exec bit,
+ * too short to classify, etc.) is fatal: zhyve exits rather than silently
+ * falling back to the platform bhyve, so operator misconfiguration is
+ * visible in the zone boot log.
  */
 
 #include <assert.h>
@@ -121,8 +125,8 @@ config_core_dumps()
 
 /*
  * If BHYVE_ZONE_PATH exists, exec it in place of the platform bhyve.
- * Returns only when BHYVE_ZONE_PATH does not exist; every other path
- * either exits or execs.
+ * Returns only when BHYVE_ZONE_PATH does not exist; every other failure
+ * exits without falling back to the platform bhyve.
  *
  * Symlinks are intentionally followed at open time so an operator can
  * swap candidates by repointing the link.
@@ -131,9 +135,12 @@ config_core_dumps()
  * concurrent rename, unlink, or symlink swap cannot change what runs.
  * #!-scripts must be exec'd by name because the kernel hands the path
  * to the interpreter, which reopens it; we resolve the fd via
- * /proc/self/path/<fd> for that case and fail closed if resolution
- * fails or would truncate.  The operator is responsible for restricting
- * write access to BHYVE_ZONE_PATH and any symlink target.
+ * /proc/self/path/<fd> to obtain a name to pass to execv, and a small
+ * swap window between readlink and execv remains for the script case.
+ * Any failure to read /proc/self/path/<fd> (error or truncation) is
+ * fatal on both branches: we always want a resolved path for logging,
+ * and the script branch needs it for execv.  The operator is responsible
+ * for restricting write access to BHYVE_ZONE_PATH and any symlink target.
  */
 static void
 try_bhyve_override(char **argv)
@@ -166,9 +173,9 @@ try_bhyve_override(char **argv)
 		    BHYVE_ZONE_PATH);
 		exit(EXIT_FAILURE);
 	}
-	if ((st.st_mode & (S_IXUSR|S_IXGRP|S_IXOTH)) == 0) {
+	if ((st.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH)) == 0) {
 		(void) fprintf(stderr, "%s: not executable (mode 0%o)\n",
-		    BHYVE_ZONE_PATH, (unsigned)(st.st_mode & 07777));
+		    BHYVE_ZONE_PATH, (unsigned int)(st.st_mode & 07777));
 		exit(EXIT_FAILURE);
 	}
 
@@ -180,41 +187,35 @@ try_bhyve_override(char **argv)
 	}
 	if (slen < (ssize_t)sizeof (shebang)) {
 		(void) fprintf(stderr, "%s: too short to classify "
-		    "(file < 2 bytes)\n", BHYVE_ZONE_PATH);
+		    "(%zd byte(s), need 2)\n", BHYVE_ZONE_PATH, slen);
 		exit(EXIT_FAILURE);
 	}
-	is_script = (shebang[0] == '#' && shebang[1] == '!');
+	is_script = (shebang[0] == '#' && shebang[1] == '!') ?
+	    B_TRUE : B_FALSE;
 
 	/*
-	 * `resolved` doubles as the script exec target and a log label.
-	 * Leave it empty if we have nothing trustworthy to print; the
-	 * banner below treats empty as "show the literal path only".
+	 * `resolved` is both the script exec target and the log label.
+	 * readlink failure or truncation is fatal on both branches.
 	 */
 	(void) snprintf(procpath, sizeof (procpath),
 	    "/proc/self/path/%d", fd);
 	rlen = readlink(procpath, resolved, sizeof (resolved) - 1);
 	if (rlen < 0) {
-		if (is_script) {
-			(void) fprintf(stderr,
-			    "cannot resolve %s via %s: %s; "
-			    "refusing to exec script\n",
-			    BHYVE_ZONE_PATH, procpath, strerror(errno));
-			exit(EXIT_FAILURE);
-		}
-		(void) fprintf(stderr,
-		    "warning: readlink(%s) failed: %s; "
-		    "proceeding with fexecve\n", procpath, strerror(errno));
-		resolved[0] = '\0';
-	} else if ((size_t)rlen >= sizeof (resolved) - 1) {
+		(void) fprintf(stderr, "readlink(%s) failed: %s; "
+		    "refusing to exec %s\n",
+		    procpath, strerror(errno), BHYVE_ZONE_PATH);
+		exit(EXIT_FAILURE);
+	}
+	if ((size_t)rlen >= sizeof (resolved) - 1) {
 		(void) fprintf(stderr,
 		    "readlink(%s) result truncated at %zd bytes; "
-		    "refusing to exec\n", procpath, rlen);
+		    "refusing to exec %s\n",
+		    procpath, rlen, BHYVE_ZONE_PATH);
 		exit(EXIT_FAILURE);
-	} else {
-		resolved[rlen] = '\0';
 	}
+	resolved[rlen] = '\0';
 
-	if (resolved[0] != '\0' && strcmp(resolved, BHYVE_ZONE_PATH) != 0) {
+	if (strcmp(resolved, BHYVE_ZONE_PATH) != 0) {
 		(void) printf("Using bhyve override at %s -> %s\n",
 		    BHYVE_ZONE_PATH, resolved);
 	} else {

--- a/usr/src/cmd/zhyve/zhyve.c
+++ b/usr/src/cmd/zhyve/zhyve.c
@@ -11,18 +11,25 @@
 
 /*
  * Copyright (c) 2018, Joyent, Inc.
+ * Copyright 2026 Edgecast Cloud LLC.
  */
 
 /*
  * This small 'zhyve' stub is init for the zone: we therefore need to pick up
  * our command-line arguments placed in ZHYVE_CMD_FILE by the boot stub, do a
  * little administration, and exec the real bhyve binary.
+ *
+ * As an optional escape hatch, if BHYVE_ZONE_PATH exists and is executable
+ * inside the zone, exec it instead of the platform's bhyve.  This lets a
+ * zone image ship an alternate bhyve (or a wrapper that performs additional
+ * setup, e.g. starting swtpm) without requiring a platform image rebuild.
  */
 
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <libnvpair.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -32,7 +39,10 @@
 #include <unistd.h>
 #include <sys/corectl.h>
 
+extern char **environ;
+
 #define	ZHYVE_CMD_FILE	"/var/run/bhyve/zhyve.cmd"
+#define	BHYVE_ZONE_PATH	"/bhyve.zone"
 
 /*
  * Do a read of the specified size or return an error.  Returns 0 on success
@@ -109,6 +119,121 @@ config_core_dumps()
 	(void) core_set_options(0x0);
 }
 
+/*
+ * If BHYVE_ZONE_PATH exists, exec it in place of the platform bhyve.
+ * Returns only when BHYVE_ZONE_PATH does not exist; every other path
+ * either exits or execs.
+ *
+ * Symlinks are intentionally followed at open time so an operator can
+ * swap candidates by repointing the link.
+ *
+ * Non-script binaries are exec'd via fexecve(3C) on the open fd, so a
+ * concurrent rename, unlink, or symlink swap cannot change what runs.
+ * #!-scripts must be exec'd by name because the kernel hands the path
+ * to the interpreter, which reopens it; we resolve the fd via
+ * /proc/self/path/<fd> for that case and fail closed if resolution
+ * fails or would truncate.  The operator is responsible for restricting
+ * write access to BHYVE_ZONE_PATH and any symlink target.
+ */
+static void
+try_bhyve_override(char **argv)
+{
+	int fd;
+	struct stat st;
+	char shebang[2];
+	ssize_t slen;
+	boolean_t is_script;
+	char procpath[PATH_MAX];
+	char resolved[PATH_MAX];
+	ssize_t rlen;
+
+	fd = open(BHYVE_ZONE_PATH, O_RDONLY | O_CLOEXEC);
+	if (fd < 0) {
+		if (errno == ENOENT)
+			return;
+		(void) fprintf(stderr, "open(%s) failed: %s\n",
+		    BHYVE_ZONE_PATH, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	if (fstat(fd, &st) != 0) {
+		(void) fprintf(stderr, "fstat(%s) failed: %s\n",
+		    BHYVE_ZONE_PATH, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+	if (!S_ISREG(st.st_mode)) {
+		(void) fprintf(stderr, "%s: not a regular file\n",
+		    BHYVE_ZONE_PATH);
+		exit(EXIT_FAILURE);
+	}
+	if ((st.st_mode & (S_IXUSR|S_IXGRP|S_IXOTH)) == 0) {
+		(void) fprintf(stderr, "%s: not executable (mode 0%o)\n",
+		    BHYVE_ZONE_PATH, (unsigned)(st.st_mode & 07777));
+		exit(EXIT_FAILURE);
+	}
+
+	slen = pread(fd, shebang, sizeof (shebang), 0);
+	if (slen < 0) {
+		(void) fprintf(stderr, "pread(%s) failed: %s\n",
+		    BHYVE_ZONE_PATH, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+	if (slen < (ssize_t)sizeof (shebang)) {
+		(void) fprintf(stderr, "%s: too short to classify "
+		    "(file < 2 bytes)\n", BHYVE_ZONE_PATH);
+		exit(EXIT_FAILURE);
+	}
+	is_script = (shebang[0] == '#' && shebang[1] == '!');
+
+	/*
+	 * `resolved` doubles as the script exec target and a log label.
+	 * Leave it empty if we have nothing trustworthy to print; the
+	 * banner below treats empty as "show the literal path only".
+	 */
+	(void) snprintf(procpath, sizeof (procpath),
+	    "/proc/self/path/%d", fd);
+	rlen = readlink(procpath, resolved, sizeof (resolved) - 1);
+	if (rlen < 0) {
+		if (is_script) {
+			(void) fprintf(stderr,
+			    "cannot resolve %s via %s: %s; "
+			    "refusing to exec script\n",
+			    BHYVE_ZONE_PATH, procpath, strerror(errno));
+			exit(EXIT_FAILURE);
+		}
+		(void) fprintf(stderr,
+		    "warning: readlink(%s) failed: %s; "
+		    "proceeding with fexecve\n", procpath, strerror(errno));
+		resolved[0] = '\0';
+	} else if ((size_t)rlen >= sizeof (resolved) - 1) {
+		(void) fprintf(stderr,
+		    "readlink(%s) result truncated at %zd bytes; "
+		    "refusing to exec\n", procpath, rlen);
+		exit(EXIT_FAILURE);
+	} else {
+		resolved[rlen] = '\0';
+	}
+
+	if (resolved[0] != '\0' && strcmp(resolved, BHYVE_ZONE_PATH) != 0) {
+		(void) printf("Using bhyve override at %s -> %s\n",
+		    BHYVE_ZONE_PATH, resolved);
+	} else {
+		(void) printf("Using bhyve override at %s\n",
+		    BHYVE_ZONE_PATH);
+	}
+
+	if (is_script) {
+		(void) execv(resolved, argv);
+		(void) fprintf(stderr, "execv(%s) failed: %s\n",
+		    resolved, strerror(errno));
+	} else {
+		(void) fexecve(fd, argv, environ);
+		(void) fprintf(stderr, "fexecve(%s) failed: %s\n",
+		    BHYVE_ZONE_PATH, strerror(errno));
+	}
+	exit(EXIT_FAILURE);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -159,6 +284,8 @@ main(int argc, char **argv)
 
 	memcpy(tmpargs, zargv, sizeof (*zargv) * zargc);
 	tmpargs[zargc] = NULL;
+
+	try_bhyve_override(tmpargs);
 
 	(void) execv("/usr/sbin/bhyve", tmpargs);
 


### PR DESCRIPTION
```
Portions generated with: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
```

zhyve: honor /bhyve.zone override for in-zone bhyve replacement

Allows a bhyve zone image to ship an alternate bhyve binary (or a wrapper script that performs additional setup such as starting swtpm) at /bhyve.zone.  If present and executable, zhyve execs it instead of /usr/sbin/bhyve.  This makes it possible to iterate on alternate bhyve builds without rebuilding and rebooting the platform image.