### PR TITLE
OS-8756 Have SmartOS usr/src/test python scripts use env(1)

### DIFF
--- a/usr/src/Makefile.testarchive
+++ b/usr/src/Makefile.testarchive
@@ -26,6 +26,7 @@ TEST_IPS_MANIFEST_FILES = \
     system-io-tests.p5m \
     system-test-cryptotest.p5m \
     system-test-elftest.p5m \
+    system-test-i2ctest.p5m \
     system-test-libctest.p5m \
     system-test-libproctest.p5m \
     system-test-libsectest.p5m \

--- a/usr/src/Makefile.testarchive
+++ b/usr/src/Makefile.testarchive
@@ -10,6 +10,7 @@
 #
 # Copyright 2021 Joyent, Inc.
 # Copyright 2024 MNX Cloud, Inc.
+# Copyright 2026 Edgecast Cloud LLC.
 #
 
 #

--- a/usr/src/test/Makefile.com
+++ b/usr/src/test/Makefile.com
@@ -11,7 +11,23 @@
 
 #
 # Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright 2026 Edgecast Cloud LLC.
 #
+
+#
+# NOTE: The @PYTHON@ macro's default is whatever is in the compilation
+# environment. On SmartOS, this is typically in /opt/local, the pkgsrc root.
+#
+# The problem which we must address here is that tests in SmartOS are entirely
+# under the control of the`smartos-test script, and that runs in the global
+# zone. As of OS-8403, the global zone pkgsrc root is assumed to be in
+# /opt/tools.
+#
+# We opt to use '/usr/bin/env python' because the smartos-test script sets PATH
+# appropriately, and is responsible for successful execution of anything here
+# in usr/src/test it runs.
+#
+PYSHEBANG=/usr/bin/env python
 
 all     :=      TARGET = all
 install :=      TARGET = install

--- a/usr/src/test/smartos-test/README
+++ b/usr/src/test/smartos-test/README
@@ -84,6 +84,8 @@ Notes on NVMe testing:
 NVMe is tested by unit tests and by non-destructive component tests.  The
 latter must specify NVME_TEST_DEVICE from nvme* names.  E.g. "nvme0".  If
 NVME_TEST_DEVICE is not set, the non-destructive component tests will not run.
+If you wish to also use destructive component tests, set NVME_DESTRUCTIVE to
+a non-empty value.
 
 Notes on ZFS testing:
 

--- a/usr/src/test/smartos-test/smartos-test.sh
+++ b/usr/src/test/smartos-test/smartos-test.sh
@@ -14,7 +14,7 @@
 #
 # Copyright 2020 Joyent, Inc.
 # Copyright 2025 MNX Cloud, Inc.
-# Copyright 2025 Edgecast Cloud LLC.
+# Copyright 2026 Edgecast Cloud LLC.
 #
 
 #
@@ -203,7 +203,7 @@ function shadow_fix {
 #
 function extract_remaining_test_bits {
     log_must tar -xzf $1 -C / \
-        opt kernel tests.manifest.gen tests.buildstamp
+        opt kernel lib tests.manifest.gen tests.buildstamp
 }
 
 # The pkgsrc packages we will install are now a single metapackage.
@@ -319,8 +319,13 @@ function nvme_test_check {
     # If we specify NVME_TEST_DEVICE, then run the non-destructive NVMe tests.
     if [[ -n "$NVME_TEST_DEVICE" ]]; then
 	log_testrunner nvme-tests /opt/nvme-tests/runfiles/non-destruct.run
+	if [[ -n "$NVME_DESTRUCTIVE" ]]; then
+	    log_testrunner nvme-tests /opt/nvme-tests/runfiles/destruct.run
+	else
+	    log "Skipping NVMe destructive tests"
+	fi
     else
-	log "Skipping NVMe non-destructive tests"
+	log "Skipping NVMe non-destructive & destructive tests"
     fi
 }
 
@@ -341,6 +346,15 @@ function os_tests_check {
     log_testrunner os-tests /opt/os-tests/runfiles/default.run
 }
 
+function i2c_tests_check {
+    # We need a driver supplied by the tests.
+    add_drv i2csim || driver_install_fail i2csim
+    # Import the i2csimd.xml SMF manifest.
+    svccfg import /lib/svc/manifest/system/i2csimd.xml
+    # OKAY, now we can run it!
+    log_testrunner i2c-tests /opt/i2c-tests/runfiles/default.run
+}
+
 #
 # By using log_test or log_testrunner, we accumulate the exit codes from each
 # test run to $RESULT.
@@ -353,13 +367,15 @@ function execute_tests {
     bhyve_test_check
     log_testrunner crypto-tests /opt/crypto-tests/runfiles/default.run
     log_testrunner elf-tests /opt/elf-tests/runfiles/default.run
+    i2c_tests_check
     log_testrunner libc-tests /opt/libc-tests/runfiles/default.run
-    log_testrunner libsec-tests /opt/libsec-tests/runfiles/default.run
     log_testrunner libproc-tests /opt/libproc-tests/runfiles/default.run
+    log_testrunner libsec-tests /opt/libsec-tests/runfiles/default.run
+    nvme_test_check
+    os_tests_check
+    log_testrunner tz-tests /opt/tz-tests/runfiles/default.run
     log_test vndtest /opt/vndtest/bin/vndtest -a
     log_testrunner util-tests /opt/util-tests/runfiles/default.run
-    os_tests_check
-    nvme_test_check
     zfs_test_check
 
     if [[ -n "$FAILED_TESTS" ]]; then

--- a/usr/src/test/smbsrv-tests/cmd/Makefile
+++ b/usr/src/test/smbsrv-tests/cmd/Makefile
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2021 Tintri by DDN, Inc. All rights reserved.
+# Copyright 2026 Edgecast Cloud LLC.
 #
 
 include $(SRC)/Makefile.master
@@ -23,4 +24,5 @@ PYSUFFIX = $(PYTHON3_SUFFIX)
 ROOTOPTPKG = $(ROOT)/opt/smbsrv-tests
 TARGETDIR = $(ROOTOPTPKG)/bin
 
+include $(SRC)/test/Makefile.com
 include $(SRC)/test/smbsrv-tests/Makefile.com

--- a/usr/src/test/test-runner/cmd/run
+++ b/usr/src/test/test-runner/cmd/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@PYTHON@
 
 #
 # This file and its contents are supplied under the terms of the
@@ -18,11 +18,8 @@
 # Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 # Copyright 2022 MNX Cloud, Inc.
 # Copyright 2026 Gordon W. Ross
+# Copyright 2026 Edgecast Cloud LLC.
 #
-
-# NOTE:  For SmartOS, the @PYTHON@ macro defaults to /opt/local, which is
-# not the case for the SmartOS global zone's pkgsrc installation (/opt/tools).
-# So use /usr/bin/env because the smartos-test script sets PATH appropriately.
 
 from __future__ import print_function
 import sys


### PR DESCRIPTION
Blocks any merge-with-upstream.